### PR TITLE
Add the form validation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ The data in the store will remain until the `PathFormProvider` is unmounted.
 
 The initial data for your form on the *initial render only*.
 
+#### PathFormProvider `mode?: 'onSubmit' | 'onChange'`
+
+Set the mode in which the validation will happen.
+
+- onSubmit (default): will run the validation when the form is submitted.
+- onChange: Validation will trigger on the change event with each input, this may trigger multiple rerenders. The PathForm.onValidate will continue to be triggered on the submit event.
+
 <br/><br/>
 
 ### PathForm

--- a/example/src/ExampleApp.tsx
+++ b/example/src/ExampleApp.tsx
@@ -5,7 +5,15 @@ import DeleteIcon from '@material-ui/icons/DeleteRounded';
 import ArrowUpIcon from '@material-ui/icons/ArrowUpwardRounded';
 import ArrowDownIcon from '@material-ui/icons/ArrowDownwardRounded';
 
-import { PathForm, PathFormArray, PathFormField, PathFormProvider, usePathForm, usePathFormValue } from '../../dist';
+import {
+  PathForm,
+  PathFormArray,
+  PathFormField,
+  PathFormProvider,
+  usePathForm,
+  usePathFormValue,
+  PathFormValidationMode,
+} from '../../dist';
 import { PathFormDevTools } from './ExamplePathFormDevTools';
 
 const fetchedData = {
@@ -17,17 +25,49 @@ const fetchedData = {
 };
 
 export const ExampleApp = () => {
+  const [mode, setMode] = React.useState<PathFormValidationMode>('onSubmit');
+
+  // This will force the form to be removed and added back to the tree, this way it's possible to change the mode
+  const [showForm, setShowForm] = React.useState(true);
+  React.useEffect(() => {
+    if (!showForm) {
+      const timeout = setTimeout(() => setShowForm(true), 100);
+      return () => clearTimeout(timeout);
+    }
+  }, [showForm]);
+
+  const onChangeMode = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setMode(e.target.value as PathFormValidationMode);
+    setShowForm(false);
+  };
+
   return (
-    <PathFormProvider initialRenderValues={fetchedData}>
-      <div style={{ display: 'flex', height: '100vh' }}>
-        <div style={{ width: 800, padding: 25 }}>
-          <MyForm />
-        </div>
-        <aside style={{ flex: 1, overflowY: 'scroll' }}>
-          <PathFormDevTools />
-        </aside>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div style={{ padding: 16, margin: 16, border: '1px solid #AAA', borderRadius: 8, backgroundColor: '#F0F0F0' }}>
+        <p style={{ margin: 0 }}>
+          <strong>Form rules</strong>
+        </p>
+        <label>
+          Select validation mode:
+          <select style={{ marginLeft: 8 }} onChange={onChangeMode}>
+            <option value="onSubmit">onSubmit</option>
+            <option value="onChange">onChange</option>
+          </select>
+        </label>
       </div>
-    </PathFormProvider>
+      {showForm && (
+        <PathFormProvider initialRenderValues={fetchedData} mode={mode}>
+          <div style={{ display: 'flex', flexGrow: 1, height: '100%' }}>
+            <div style={{ width: 800, padding: 25 }}>
+              <MyForm />
+            </div>
+            <aside style={{ flex: 1, overflowY: 'scroll' }}>
+              <PathFormDevTools />
+            </aside>
+          </div>
+        </PathFormProvider>
+      )}
+    </div>
   );
 };
 

--- a/src/PathFormField.tsx
+++ b/src/PathFormField.tsx
@@ -35,7 +35,7 @@ export interface PathFormFieldProps {
 export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defaultValue, validations, publish }) => {
   const name = usePathFormDotPath(path);
   const [value, meta, renders] = usePathFormValue(path, defaultValue); // TODO defaultValue needed?
-  const { setValue, setMeta, clearError, watchers } = usePathForm();
+  const { setValue, setMeta, clearError, watchers, state } = usePathForm();
 
   const onChange = React.useCallback(
     (event: any) => {
@@ -62,7 +62,7 @@ export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defa
       const blurValue = event?.target?.value ?? event;
 
       // if the field has an error, and our blur value is different than the error value, clear the error
-      if (Boolean(meta?.error) && blurValue !== meta?.error?.value) {
+      if (Boolean(meta?.error) && blurValue !== meta?.error?.value && state.current.mode !== 'onChange') {
         clearError(path);
       }
 
@@ -70,7 +70,7 @@ export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defa
         setMeta(path, { touched: true });
       }
     },
-    [path, clearError, setMeta, meta]
+    [path, clearError, setMeta, meta, state.current.mode]
   );
 
   // TODO reusable hook for usePathFormValidation -> useEffect [validations]


### PR DESCRIPTION
## Summary
This PR is meant to add an onChange validation mode in addition to the default onSubmit.

## Changes
- onChange validation mode makes it run the input validation on every onChange event
- Update the docs
- Update the example

## Example
https://user-images.githubusercontent.com/191252/175195875-0ed73edb-ab58-4e8d-93bd-be76db306af7.mp4
